### PR TITLE
refactor: mundança de widget e paleta de cores

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:frontend/screens/home/home_view_model.dart';
 
 Future<void> main() async {
-  final habitoService = HabitoService(baseUrl: 'http://192.168.15.14:3000');
+  final habitoService = HabitoService(baseUrl: 'http://192.168.0.173:3000');
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting('pt_BR', null);
   runApp(

--- a/frontend/lib/screens/home/home_view.dart
+++ b/frontend/lib/screens/home/home_view.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:date_picker_timeline/date_picker_timeline.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import '../../model/habitos_model.dart';
 import '../home/home_view_model.dart';
+import 'package:easy_date_timeline/easy_date_timeline.dart';
+import 'package:material_symbols_icons/material_symbols_icons.dart';
 
 class HomeView extends StatefulWidget {
   const HomeView({super.key});
@@ -13,31 +14,58 @@ class HomeView extends StatefulWidget {
 }
 
 class _HomeViewState extends State<HomeView> {
-  DateTime _selectedValue = DateTime(DateTime.now().year, DateTime.now().month, 1);
+  final EasyDatePickerController _controller = EasyDatePickerController();
+  DateTime _selectedValue = DateTime(
+    DateTime.now().year,
+    DateTime.now().month,
+    DateTime.now().day,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _controller.jumpToCurrentDate(); // Centraliza a data atual
+    });
+  }
 
   Widget _buildTile(String title, int value, Color color, IconData icon) {
     return ListTile(
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      tileColor: const Color(0xFF222222),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      tileColor: Color(0xFFf5f5f5),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      leading: Icon(icon, color: Colors.white),
       title: Text(
         title,
         style: const TextStyle(
-          fontSize: 18,
+          fontSize: 16,
           fontWeight: FontWeight.bold,
-          color: Colors.white,
+          color: Color(0xFF222222),
         ),
       ),
-      trailing: CircleAvatar(
-        radius: 20,
-        backgroundColor: color,
-        child: Text(
-          value.toString(),
-          style: const TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.bold,
-          ),
+
+      trailing: Container(
+        width: 80,
+        height: 40,
+        alignment: Alignment.center,
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        decoration: BoxDecoration(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: color, size: 20),
+            SizedBox(width: 6),
+            Text(
+              value.toString(),
+              style: TextStyle(
+                fontSize: 18,
+                color: color,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -46,35 +74,148 @@ class _HomeViewState extends State<HomeView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFFF9F9F9),
+      backgroundColor: Color(0xFFFFFFFF),
       body: Padding(
         padding: const EdgeInsets.all(34),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            const SizedBox(height: 20),
-            DatePicker(
-              DateTime(DateTime.now().year, DateTime.now().month, 1),
-              initialSelectedDate: _selectedValue,
-              selectionColor: const Color(0xFF222222),
-              selectedTextColor: Colors.white,
-              locale: "pt_BR",
-              onDateChange: (date) {
-                setState(() {
-                  _selectedValue = date;
-                });
-              },
+            SizedBox(height: 20),
+            AppBar(
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              title: const Text(
+                'Meus Hábitos',
+                style: TextStyle(
+                  color: Color(0xFF222222),
+                  fontSize: 24,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              centerTitle: true,
             ),
-            const SizedBox(height: 20),
-            Text(
-              DateFormat(
-                "dd 'de' MMMM 'de' yyyy",
-                "pt_BR",
-              ).format(_selectedValue),
-              style: const TextStyle(fontSize: 18),
+
+            Theme(
+              data: Theme.of(context).copyWith(
+                colorScheme: ColorScheme.fromSwatch(
+                  backgroundColor: Color(0xFFf5f5f5), // Cor de fundo do tema
+                ).copyWith(primary: Color(0xFF222222)), //Cor primária do tema
+              ),
+              child: EasyTheme(
+                data: EasyTheme.of(context).copyWith(
+                  monthBackgroundColor: WidgetStateProperty.resolveWith((
+                    states,
+                  ) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Color(
+                        0xFF222222,
+                      ); // Cor de fundo do mês selecionado
+                    }
+                    return Colors.transparent; // Cor de fundo padrão
+                  }),
+
+                  monthForegroundColor: WidgetStateProperty.resolveWith((
+                    states,
+                  ) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Colors.white; // Cor do texto do mês selecionado
+                    }
+                    return Color(0xFF222222); // Cor do texto padrão
+                  }),
+
+                  monthBorder: WidgetStateProperty.resolveWith((states) {
+                    if (states.contains(WidgetState.selected)) {
+                      return const BorderSide(color: Colors.transparent); 
+                    }
+                    return const BorderSide(color: Colors.transparent);
+                  }),
+
+                  currentMonthBackgroundColor: WidgetStateProperty.resolveWith((
+                    states,
+                  ) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Color(0xFF222222); // Cor de fundo do mês atual
+                    }
+                    return Colors.transparent; // Cor de fundo padrão
+                  }),
+
+                  currentMonthForegroundColor: WidgetStateProperty.resolveWith((
+                    states,
+                  ) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Colors.white; // Cor do texto do mês selecionado
+                    }
+                    return Color(0xFF222222); // Cor do texto padrão
+                  }),
+                  currentMonthBorder: WidgetStateProperty.all(
+                    const BorderSide(color: Color(0xFF222222)), // Cor da borda do mês atual
+                  ),
+
+                  dayBackgroundColor: WidgetStateProperty.resolveWith((states) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Color(0xFF222222); // Cor de fundo do dia selecionado
+                    } else if (states.contains(WidgetState.disabled)) {
+                      return Color(0xFFf5f5f5); // Cor de fundo do dia desabilitado
+                    }
+                    return Color(0xFFf5f5f5); // Cor de fundo padrão
+                  }),
+                  dayForegroundColor: WidgetStateProperty.resolveWith((states) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Colors.white;
+                    }
+                    return Color(0xFF222222); // Cor do texto padrão
+                  }),
+                  dayBorder: WidgetStateProperty.resolveWith((states) {
+                    if (states.contains(WidgetState.selected)) {
+                      return const BorderSide(color: Colors.transparent);
+                    }
+                    return const BorderSide(color: Colors.transparent);
+                  }),
+                  dayShape: WidgetStateProperty.all(
+                    RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  currentDayBackgroundColor: WidgetStateProperty.resolveWith((
+                    states,
+                  ) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Color(0xFF222222); // Cor de fundo do dia atual
+                    }
+                    return Colors.transparent;
+                  }),
+                  currentDayForegroundColor: WidgetStateProperty.resolveWith((
+                    states,
+                  ) {
+                    if (states.contains(WidgetState.selected)) {
+                      return Colors.white; // Cor do texto do dia atual
+                    }
+                    return Color(0xFF222222); // Cor do texto padrão
+                  }),
+                  currentDayBorder: WidgetStateProperty.all(
+                    const BorderSide(color: Color(0xFF222222)), // Cor da borda do dia atual
+                  ),
+                ),
+                child: EasyDateTimeLinePicker(
+                  controller: _controller,
+                  locale: const Locale("pt", "BR"),
+                  focusedDate: _selectedValue,
+                  firstDate: DateTime(
+                    DateTime.now().year,
+                    DateTime.now().month,
+                    1,
+                  ),
+                  lastDate: DateTime(2030, 3, 18),
+                  onDateChange: (date) {
+                    setState(() {
+                      _selectedValue = date;
+                    });
+                  },
+                ),
+              ),
             ),
+
             const SizedBox(height: 20),
-            // Consumer para atualizar os ListTile quando os dados mudarem
             Consumer<HabitoViewModel>(
               builder: (context, habitoViewModel, child) {
                 final formattedDate = DateFormat(
@@ -97,32 +238,33 @@ class _HomeViewState extends State<HomeView> {
 
                 return Column(
                   children: [
+                    SizedBox(height: 20),
                     _buildTile(
-                      'Bebeu Água',
+                      'Copos de Água Bebidos',
                       currentHabit.contadorAgua,
-                      const Color(0xFF379392),
-                      Icons.local_drink,
+                      Color(0xFF3A86FF),
+                      Symbols.water_drop,
                     ),
-                    const SizedBox(height: 10),
+                    SizedBox(height: 20),
                     _buildTile(
-                      'Sessões Pomodoro',
+                      'Sessões Pomodoro Concluídas',
                       currentHabit.contadorPomodoro,
-                      const Color(0xFFC30232),
-                      Icons.timer,
+                      Color(0xFFE63946),
+                      Symbols.alarm,
                     ),
-                    const SizedBox(height: 10),
+                    SizedBox(height: 20),
                     _buildTile(
                       'Pausas para Exercícios',
                       currentHabit.contadorExercicio,
-                      const Color(0xFF7067CF),
-                      Icons.fitness_center,
+                      Color(0xFF06D6A0),
+                      Symbols.exercise,
                     ),
-                    const SizedBox(height: 10),
+                    SizedBox(height: 20),
                     _buildTile(
-                      'Refeições Feitas',
+                      'Refeições Saudáveis Feitas',
                       currentHabit.contadorRefeicao,
-                      const Color(0xFFFF8811),
-                      Icons.fastfood,
+                      Color(0xFFF4A261),
+                      Symbols.lunch_dining,
                     ),
                   ],
                 );

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  chalkdart:
+    dependency: transitive
+    description:
+      name: chalkdart
+      sha256: "82dfa884e3cf97641eb0742a3b9ffd41490666b9ece548b2e32cbfefe540bf86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   characters:
     dependency: transitive
     description:
@@ -49,22 +57,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
-  date_picker_timeline:
-    dependency: "direct main"
-    description:
-      name: date_picker_timeline
-      sha256: c05e6540fa3055c9036e6f99e758972e14be0e1010d5a6e7a1261d4a6f3292df
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.6"
   dotenv:
     dependency: "direct main"
     description:
@@ -73,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  easy_date_timeline:
+    dependency: "direct main"
+    description:
+      name: easy_date_timeline
+      sha256: "0fb8fe360d78b7ccb409da9de0e8a71e8e06f0e8a60ea6c54dabf830479309b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.9"
   fake_async:
     dependency: transitive
     description:
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,11 +102,24 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  glob:
+    dependency: transitive
+    description:
+      name: glob
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
   http:
     dependency: "direct main"
     description:
@@ -171,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  material_symbols_icons:
+    dependency: "direct main"
+    description:
+      name: material_symbols_icons
+      sha256: "99d5b0e7c65232dfe1247e0ac67eeeee2cab9da2d860748fc495d34f5e9e6397"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2811.0"
   meta:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -33,12 +33,12 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
-  date_picker_timeline: ^1.2.6
   intl: ^0.19.0
   http: ^1.3.0
   provider: ^6.1.2
   dotenv: ^4.2.0
+  easy_date_timeline: ^2.0.9
+  material_symbols_icons: ^4.2811.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Descrição
Refatoração da tela do sistema, alterando tanto a paleta de cores quanto o widget de seleção de data.

## Alterações realizadas
- [x] Refatoração de widget de seleção de data;
- [ ] Nova paleta de cores minimalista

## Screenshots
![Captura de tela 2025-03-29 214245](https://github.com/user-attachments/assets/a9d01526-cb9d-44de-aac2-f52e406c6097)

## Checklist
- [x] O código segue o padrão de estilo definido
- [ ] Testes foram criados ou ajustados (se necessário)
- [x] Documentação foi atualizada (se necessário)
- [x] O código foi testado manualmente

## Observação
É possível ainda trazer um design style chamado Neumosfismo, com intuito de trazer maior profundidade aos elementos da tela, mantendo o minimalismo da mesma. Alguns exemplos de aplicação:

![Design concept for smart home app 🛸](https://github.com/user-attachments/assets/0a4232d0-3f01-4d19-a7de-0d223106c9cd)
![Neumorphism vibe](https://github.com/user-attachments/assets/91bc6df7-eb95-4fca-8454-a67565d2838f)
![Neo Capsule Hostel (Smart home + Neumorphizm)](https://github.com/user-attachments/assets/97625a8c-bd40-467c-b5d4-f8ef6526d45f)
